### PR TITLE
Do not use jade_merge if it is not needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -435,7 +435,11 @@ Compiler.prototype = {
             var val = this.attrs(attrs);
             attrsBlocks.unshift(val);
           }
-          this.buf.push('attributes: ' + this.runtime('merge') + '([' + attrsBlocks.join(',') + '])');
+          if (attrsBlocks.length > 1) {
+            this.buf.push('attributes: ' + this.runtime('merge') + '([' + attrsBlocks.join(',') + '])');
+          } else {
+            this.buf.push('attributes: ' + attrsBlocks[0]);
+          }
         } else if (attrs.length) {
           var val = this.attrs(attrs);
           this.buf.push('attributes: ' + val);


### PR DESCRIPTION
Input:

``` jade
mixin foo
  // foo

body
  +foo&attributes({class: "hello"})
```

Before:

``` js
buf.push("<body>");
jade_mixins["foo"].call({
  attributes: jade_merge([{
    class: "hello"
  }])
});
buf.push("</body>");
```

After:

``` js
buf.push("<body>");
jade_mixins["foo"].call({
  attributes: {
    class: "hello"
  }
});
buf.push("</body>");
```
