### PR TITLE
Better error report for interpolation bracket mismatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var doctypes = require('doctypes');
 var buildRuntime = require('jade-runtime/build');
 var runtime = require('jade-runtime');
 var compileAttrs = require('jade-attrs');
+var jadeError = require('jade-error');
 var selfClosing = require('void-elements');
 var parseJSExpression = require('character-parser').parseMax;
 var constantinople = require('constantinople');
@@ -88,13 +89,9 @@ Compiler.prototype = {
     }
   },
 
-  error: function (message, code, node) {
-    var err = new Error(message + ' on line ' + node.line + ' of ' + node.filename);
-    err.code = 'JADE:' + code;
-    err.msg = message;
-    err.line = node.line;
-    err.filename = node.filename;
-    throw err;
+  error: function (code, message, node) {
+    node = node || {};
+    throw jadeError(code, message, { line: node.line, filename: node.filename });
   },
 
   /**
@@ -540,7 +537,7 @@ Compiler.prototype = {
           tag.block.nodes.some(function (tag) {
             return tag.type !== 'Text' || !/^\s*$/.test(tag.val)
           })) {
-        this.error(name + ' is self closing and should not have content.', 'SELF_CLOSING_CONTENT', tag);
+        this.error('SELF_CLOSING_CONTENT', name + ' is self closing and should not have content.', tag);
       }
     } else {
       // Optimize attributes buffering

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "constantinople": "^3.0.1",
     "doctypes": "^1.0.0",
     "jade-attrs": "^1.0.2",
+    "jade-error": "^1.0.0",
     "jade-runtime": "^1.0.0",
     "js-stringify": "^1.0.1",
     "void-elements": "^2.0.1",


### PR DESCRIPTION
Fixes jadejs/jade#1922.

```
Error: Jade:2
    1| p a
  > 2| +e.value Created #{moment(profileUser.created).format('DD.MM.YY LT')
    3| div

End of line was reached with no closing bracket for interpolation.
    at compileBody (/home/timothy-gu/jade/lib/index.js:102:9)
    at Object.exports.compile (/home/timothy-gu/jade/lib/index.js:159:16)
```
