### PR TITLE
Use XML-style closing tag for explicitly stated self-closing tags in HTML as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -531,9 +531,11 @@ Compiler.prototype = {
       this.buffer('<');
       bufferName();
       this.visitAttributes(tag.attrs, tag.attributeBlocks.slice());
-      this.terse
-        ? this.buffer('>')
-        : this.buffer('/>');
+      if (this.terse && !tag.selfClosing) {
+        this.buffer('>');
+      } else {
+        this.buffer('/>');
+      }
       // if it is non-empty throw an error
       if (tag.block &&
           !(tag.block.type === 'Block' && tag.block.nodes.length === 0) &&


### PR DESCRIPTION
Fixes jadejs/jade#2082.
