### PR TITLE
Error out on using self-closing tags with buffered code

### DIFF
--- a/index.js
+++ b/index.js
@@ -570,7 +570,8 @@ Compiler.prototype = {
         ? this.buffer('>')
         : this.buffer('/>');
       // if it is non-empty throw an error
-      if (tag.block &&
+      if (tag.code ||
+          tag.block &&
           !(tag.block.type === 'Block' && tag.block.nodes.length === 0) &&
           tag.block.nodes.some(function (tag) {
             return tag.type !== 'Text' || !/^\s*$/.test(tag.val)


### PR DESCRIPTION
Originally,

``` jade
img hey
```

throws an error but

``` jade
img= hey
```

doesn't. This PR fixes that.
