### PR TITLE
Fix documentation for compileDebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Generate a JavaScript function string for the given AST.
 `options` may contain the following properties that have the same meaning as the options with the same names in `pug`:
 
  - pretty (boolean): default is `false`
- - compileDebug (boolean): default is `false`
+ - compileDebug (boolean): default is `true`
  - doctype (string): default is `undefined`
  - inlineRuntimeFunctions (boolean): default is `false`
  - globals (array of strings): default is `[]`


### PR DESCRIPTION
It defaults to `true` per [L61](https://github.com/pugjs/pug-code-gen/blob/16d83f1e0c9fb3b9490c16a53d9ce570a82183dd/index.js#L61).